### PR TITLE
fixed seek to the end on empty slice issue

### DIFF
--- a/slicewriteseek.go
+++ b/slicewriteseek.go
@@ -62,7 +62,11 @@ func (sws *SliceWriteSeeker) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekCurrent:
 		sws.Index = sws.Index + offset
 	case io.SeekEnd:
-		sws.Index = (sws.Len() - 1) + offset
+		end := sws.Len() - 1
+		if end < 0 {
+			end = 0
+		}
+		sws.Index = end + offset
 	}
 	return sws.Index, nil
 }

--- a/slicewriteseek_test.go
+++ b/slicewriteseek_test.go
@@ -37,6 +37,9 @@ func TestLen(t *testing.T) {
 
 func TestSeek(t *testing.T) {
 	s := New()
+	if off, err := s.Seek(0, io.SeekEnd); err != nil || off != 0 {
+		t.Error("Expecting offset to be zero at the end of an empty slice")
+	}
 	if _, err := s.Write([]byte{1, 2, 4}); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Hi,

There was an issue when seeking to the end of slice. When I try to seek to the end of an empty slice the returned offset is `-1` but it should be `0`.

I tested the os.File behaviour and it returned zero instead of `-1`. Here is my snippet to test this:
(test is an empty file)
```go
package main

import (
	"fmt"
	"os"
)

func main() {
	f, err := os.Open("test")
	if err != nil {
		panic(err)
	}
	defer f.Close()

	n, err := f.Seek(0, os.SEEK_END)
	fmt.Println(n, err)
}
```
Output:
```
0 <nil>
```

So I wrote this patch to fix this.