### PR TITLE
Fix the Seek behavior that is inconsistent with the standard file API

### DIFF
--- a/slicewriteseek.go
+++ b/slicewriteseek.go
@@ -21,7 +21,7 @@ func (sws *SliceWriteSeeker) Len() int64 {
 func (sws *SliceWriteSeeker) Read(p []byte) (n int, err error) {
 	toRead := sws.Index + int64(len(p))
 	switch {
-	case sws.Index+1 == sws.Len():
+	case sws.Index == sws.Len():
 		p = []byte{}
 	case toRead <= sws.Len():
 		p = sws.Buffer[sws.Index : int(sws.Index)+len(p)]
@@ -38,11 +38,11 @@ func (sws *SliceWriteSeeker) Write(p []byte) (n int, err error) {
 	switch {
 	case sws.Len() == 0:
 		sws.Buffer = p
-		sws.Index = int64(len(p)) - 1
-	case sws.Index+1 == sws.Len():
+		sws.Index = int64(len(p))
+	case sws.Index == sws.Len():
 		sws.Buffer = append(sws.Buffer, p...)
 		sws.Index += writeLen
-	case sws.Index+1 < sws.Len():
+	case sws.Index < sws.Len():
 		switch {
 		case sws.Index+writeLen > sws.Len():
 			sws.Buffer = append(sws.Buffer[:sws.Index], p...)
@@ -62,11 +62,7 @@ func (sws *SliceWriteSeeker) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekCurrent:
 		sws.Index = sws.Index + offset
 	case io.SeekEnd:
-		end := sws.Len() - 1
-		if end < 0 {
-			end = 0
-		}
-		sws.Index = end + offset
+		sws.Index = sws.Len() + offset
 	}
 	return sws.Index, nil
 }

--- a/slicewriteseek_test.go
+++ b/slicewriteseek_test.go
@@ -43,17 +43,20 @@ func TestSeek(t *testing.T) {
 	if _, err := s.Write([]byte{1, 2, 4}); err != nil {
 		t.Error(err)
 	}
+	if off, err := s.Seek(0, io.SeekCurrent); err != nil || off != 3 {
+		t.Error("Unexpected seek")
+	}
 	if off, err := s.Seek(0, io.SeekStart); err != nil || off != 0 {
 		t.Error("Unexpected seek")
 	}
 	if s.Buffer[s.Index] != 1 {
 		t.Errorf("Expecting first item to be 1, got %v", s.Buffer[s.Index])
 	}
-	if off, err := s.Seek(0, io.SeekEnd); err != nil || off != 2 {
+	if off, err := s.Seek(0, io.SeekEnd); err != nil || off != 3 {
 		t.Error("Unexpected seek")
 	}
-	if s.Buffer[s.Index] != 4 {
-		t.Errorf("Expecting last item to be 4, got %v", s.Buffer[s.Index])
+	if s.Buffer[s.Index-1] != 4 {
+		t.Errorf("Expecting last item to be 4, got %v", s.Buffer[s.Index-1])
 	}
 	s.Index = 1
 	if off, err := s.Seek(0, io.SeekCurrent); err != nil || off != 1 {


### PR DESCRIPTION
Fix the Seek behavior that is inconsistent with the standard file interface, clearly defining the Index member variable as the byte index to be read or written, not the last byte index read or written.

All unit tests are passed, but there may be interface compatibility issues because Index and Seek return values.